### PR TITLE
change base docker image? (opinion request)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4
+FROM buildpack-deps:jessie
 
 MAINTAINER risetechnologies
 


### PR DESCRIPTION
Let this be more kind of discussion rather than actual request for change. 

I suppose this image serves a purpose to build the Meteor application (i.e. as part of CI process) and not run the build afterwards. And since Meteor downloads the Node.js version it needs, there is no need to install it before. Using more simple base image seems the way to go...

But that's my first impression. I didn't actually test the image size or build time. I'd just like to ask for your opinion - wouldn't it be better to use smaller base image (the `buildpack-deps:jessie` is actually node image `FROM` dependency)?

Also - thank you for making this straight-forward Meteor docker image! In my CI process I normally use different image for building the app and different one to run it... and surprisingly, it took me some time to find the simple docker image that would let me do just that - build the app. So, thumbs up! :+1: 